### PR TITLE
Avoid outputting password in service file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,7 @@
     owner: root
     group: root
     mode: 0644
+  no_log: true
   notify:
     - restart mysqld exporter
 


### PR DESCRIPTION
Currently passwords are displayed when making changes to `mysqld_exporter.service` file.

```
TASK [create mysqld-exporter user] ****************************************************************************************************
changed: [vm3_devstack]
--- before: /etc/systemd/system/mysqld_exporter.service
+++ after: /Users/nsmeds/.ansible/tmp/ansible-local-4523tmnoosfj/tmp3ak6s8a4/mysqld_exporter.service.j2
@@ -6,7 +6,7 @@
 Type=simple
 User=mysqld-exp
 Group=mysqld-exp
-Environment="DATA_SOURCE_NAME=prometheus:secret_password1@(localhost:3306)/"
+Environment="DATA_SOURCE_NAME=prometheus:secret_password2@(localhost:3306)/"
 ExecStart=/usr/local/bin/mysqld_exporter \
     --web.listen-address 0.0.0.0:9104 \
```

This should be prevented.