### PR TITLE
move to ansible 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ cache: pip
 services:
   - docker
 env:
-  - ANSIBLE=2.4
   - ANSIBLE=2.5
   - ANSIBLE=2.6
+  - ANSIBLE=2.7
 install:
   - pip install tox-travis git-semver
 script:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Deploy prometheus [mysqld exporter](https://github.com/prometheus/mysqld_exporte
 
 ## Requirements
 
-- Ansible >= 2.3
+- Ansible >= 2.5 (It might work on previous versions, but we cannot guarantee it)
 
 ## Role Variables
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Pawel Krupa
   description: Prometheus Mysqld Exporter
   license: MIT
-  min_ansible_version: 2.3
+  min_ansible_version: 2.5
   platforms:
   - name: Ubuntu
     versions:

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,20 @@
 [tox]
 minversion = 1.8
-envlist = py{27}-ansible{24,25,26}
+envlist = py{27}-ansible{25,26,27}
 skipsdist = true
 
 [travis:env]
 ANSIBLE=
-  2.4: ansible24
   2.5: ansible25
   2.6: ansible26
+  2.7: ansible27
 
 [testenv]
 passenv = *
 deps =
     -rtest-requirements.txt
-    ansible24: ansible<2.5
     ansible25: ansible<2.6
     ansible26: ansible<2.7
+    ansible26: ansible<2.8
 commands =
     {posargs:molecule test --all --destroy always}

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ deps =
     -rtest-requirements.txt
     ansible25: ansible<2.6
     ansible26: ansible<2.7
-    ansible26: ansible<2.8
+    ansible27: ansible<2.8
 commands =
     {posargs:molecule test --all --destroy always}


### PR DESCRIPTION
[Ansible 2.7 was just released](https://github.com/ansible/ansible/releases/tag/v2.7.0) :tada:. This PR deprecates support for ansible 2.4 and introduces testing on ansible 2.7

Merging this will result in a [patch] version release.